### PR TITLE
User agent changes, speed up iso checking for multiple arches, minor cleanup

### DIFF
--- a/backend/makeisolists-combined.pl
+++ b/backend/makeisolists-combined.pl
@@ -395,7 +395,7 @@ sub get_fileinfo {
 
 	my $ua = LWP::UserAgent->new;
 	$ua->timeout(10);
-	$ua->agent('CentOS makeisolist/9q ');
+	$ua->agent('CentOS-makeisolists/9q ');
 	$ua->max_redirect(0);
 	my $res = '';
 	my $length = 0;

--- a/backend/makeisolists-combined.pl
+++ b/backend/makeisolists-combined.pl
@@ -88,11 +88,12 @@ $db->do("DELETE FROM master_iso_fileinfo WHERE checked < date_sub(now(), interva
 
 my $masterhttp = "http://master-admin.centos.org/";
 
+my %checkedonce = ( );  # mirror IDs (incl. protocol) that were checked at least once in this session
+my %http_errors = ( );	# keep track of how many HTTP errors (30x, 403, 404) we got from this mirror (mirror_id + protocol)
+
 foreach my $arch (shuffle @arches) {
 	my %iso_info = ();	# hash of master file info by iso_id
 	my %iso_filenames = ();	# hash of filenames by iso_id
-	my %checkedonce = ( );  # mirror IDs (incl. protocol) that were checked at least once in this session
-	my %http_errors = ( );	# keep track of how many HTTP errors (30x, 403, 404) we got from this mirror (mirror_id + protocol)
 	my $res;
 	my $ref;
 

--- a/backend/makemirrorlists-combined.pl
+++ b/backend/makemirrorlists-combined.pl
@@ -617,6 +617,7 @@ sub get_file
 	$url =~ s!/atomic/(.+?)/repo/repodata/repomd.xml$!/atomic/$1/repo/summary!;
 
 	my $ua = LWP::UserAgent->new;
+	$ua->agent('CentOS-makemirrorlists/9q ');
 	
 	# don't follow redirects
 	$ua->max_redirect(0);

--- a/frontend/ml.py
+++ b/frontend/ml.py
@@ -69,7 +69,7 @@ def home():
   
   response.content_type= 'text/plain'
   bottle.TEMPLATES.clear() 
-  return template(tn, rel=release, repo=repo, arch=arch)
+  return template(tn)
 
 @route('/<pth:re:.*>')
 def nothere(pth):


### PR DESCRIPTION
The user agent is now set to "CentOS-makeisolists" and "CentOS-makemirrorlists".

If a mirror was reachable when retrieving i386 .isos, it probably doesn't suddenly become unreachable when retrieving x86_64 isos, so previously cached information can be used in this case. If there is no cached information, all architectures will get checked.

ml.py passed unused variables to the template file.