### PR TITLE
Add $release to some queries

### DIFF
--- a/backend/makeisolists-combined.pl
+++ b/backend/makeisolists-combined.pl
@@ -137,7 +137,7 @@ foreach my $arch (shuffle @arches) {
 
 			# see if the value has changed since the last time
 			$res = $db->prepare("SELECT value FROM master_iso_fileinfo
-				WHERE iso_id=$iso_id;");
+				WHERE iso_id=$iso_id AND version='$release';");
 			$res->execute();
 			my $ref = $res->fetchrow_hashref();
 			my $oldvalue = $$ref{"value"};
@@ -146,7 +146,7 @@ foreach my $arch (shuffle @arches) {
 			if($finfo ne $oldvalue) {
 				logprint (2, "$iso new value $finfo, old value $oldvalue\n");
 				# information changed, invalidate old cached mirror data
-				$db->do("DELETE from valid_iso_mirrors WHERE iso_id=$iso_id;");
+				$db->do("DELETE from valid_iso_mirrors WHERE iso_id=$iso_id AND version='$release';");
 			}
 			$db->do("REPLACE INTO master_iso_fileinfo (iso_id, version, value, checked)
 				VALUES ($iso_id, '$release', '$finfo', now());");


### PR DESCRIPTION
The intention was that this script could handle the situation where an .iso with the same unversioned name but different contents existed in two separate CentOS versions. Think boot.iso, although that .iso is
served as an NetInstall image via isoredirect.

The lack of $version in these two queries was a bug, but it didn't really affect anything because all the current .isos have a version string embedded in their names.

There is no need to deploy this version yet, I have another change in the pipeline that would benefit from pushing to production.