### PR TITLE
Check if mirror has dir listing enabled

### DIFF
--- a/backend/makeisolists-combined.pl
+++ b/backend/makeisolists-combined.pl
@@ -347,10 +347,10 @@ foreach my $arch (shuffle @arches) {
 							$db->do("REPLACE INTO valid_iso_mirrors (iso_id, version, mirror_id, proto, checked)
 								VALUES (0, '$release', $mirror_id, '$proto', now());");
 						} else {
-							print "$url did not have a directory listing\n";
+							logprint (1, "$url did not have a directory listing\n");
 						}
 					} else {
-						print "$url error - " . $lwpres->status_line . "\n";
+						logprint (1, "$url error - " . $lwpres->status_line . "\n");
 					}
 				}
 				if(defined($valid_mirrors{"$mirror_id $proto 0"})) {


### PR DESCRIPTION
There are some mirrors that do not have directory listings enabled. In some cases the web server software does not have the directory listing capability at all. Yum does not care about directory listings, but directory listings are most useful for .iso downloads, because many links point on centos.org point to mirrors' 7/isos/x86_64 etc directories.

This change drops those mirrors from isoredirect.c.o's listing, except for those isoredirect.c.o links that point to the individual .iso images.