### PR TITLE
Changes for CentOS 8 isoredirect service

### DIFF
--- a/backend/makeisolists-combined.pl
+++ b/backend/makeisolists-combined.pl
@@ -101,15 +101,15 @@ foreach my $arch (shuffle @arches) {
 			
 	# read the master sha256sum file
 	my $filetype = "isos";
-	my $isourl = "$release/$filetype/$arch/";
-	my $isosha256url = "${isourl}sha256sum.txt";
+	my $checksumfilename = "sha256sum.txt";
 	if($release !~ /^[67]/) {
 		if($arch eq "armhfp") {
 			$filetype = "images";
-			$isourl = "$release/$filetype/$arch/";
 		}
-		$isosha256url = "${isourl}CHECKSUM";
+		$checksumfilename = "CHECKSUM";
 	}
+	my $isourl = "$release/$filetype/$arch/";
+	my $isosha256url = "${isourl}${checksumfilename}";
 		
 	my $sha256list = get_isolist("${masterhttp}${centos_or_altarch}/$isosha256url");
 

--- a/backend/makeisolists-combined.pl
+++ b/backend/makeisolists-combined.pl
@@ -100,8 +100,17 @@ foreach my $arch (shuffle @arches) {
 	############## get master iso lists ##########
 			
 	# read the master sha256sum file
-	my $isourl = "$release/isos/$arch/";
+	my $filetype = "isos";
+	my $isourl = "$release/$filetype/$arch/";
 	my $isosha256url = "${isourl}sha256sum.txt";
+	if($release !~ /^[67]/) {
+		if($arch eq "armhfp") {
+			$filetype = "images";
+			$isourl = "$release/$filetype/$arch/";
+		}
+		$isosha256url = "${isourl}CHECKSUM";
+	}
+		
 	my $sha256list = get_isolist("${masterhttp}${centos_or_altarch}/$isosha256url");
 
 	if($debug == 0){
@@ -194,7 +203,7 @@ foreach my $arch (shuffle @arches) {
 		push(@allccs, $$ref{"cc"});
 	}
 
-	system("mkdir $outputdir/ipv4/${centos_or_altarch}/$release/isos/$arch -p");
+	system("mkdir $outputdir/ipv4/${centos_or_altarch}/$release/$filetype/$arch -p");
 
 	foreach my $cc (shuffle ("%", @allccs, @centos_codes, keys %country_subregions)) {
 		logprint (2, "cc: $cc\n");
@@ -366,10 +375,10 @@ foreach my $arch (shuffle @arches) {
 			logprint (2, "ISO - $iso\n$okisos{$iso}\n");
 		}
 
-		unlink glob("$outputdir/ipv4/${centos_or_altarch}/$release/isos/$arch/*.$save_cc");
+		unlink glob("$outputdir/ipv4/${centos_or_altarch}/$release/$filetype/$arch/*.$save_cc");
 
 		foreach my $iso (keys(%okisos)) {
-			my $outfile = "$outputdir/ipv4/${centos_or_altarch}/$release/isos/$arch/$iso.$save_cc";
+			my $outfile = "$outputdir/ipv4/${centos_or_altarch}/$release/$filetype/$arch/$iso.$save_cc";
 
 			if (open (OUT, ">$outfile")) {
 				print OUT "$okisos{$iso}";
@@ -380,7 +389,7 @@ foreach my $arch (shuffle @arches) {
 			}
 		}
 				
-		my $isofile = "$outputdir/ipv4/${centos_or_altarch}/$release/isos/$arch/iso.$save_cc";
+		my $isofile = "$outputdir/ipv4/${centos_or_altarch}/$release/$filetype/$arch/iso.$save_cc";
 				
 		if($okmirrors) {
 			if (open (OUT, ">$isofile")) {
@@ -414,7 +423,18 @@ sub get_isolist {
 
 	if ($lwpres->is_success) {
 		my $isolist = $lwpres->content;
-		return $isolist;
+		if($url =~ /sha256sum.txt$/) {
+			return $isolist;
+		} else {
+			# convert CHECKSUM file format to regular sha256sum file format
+			my $retval = "";
+			foreach my $row (split '\n', $isolist) {
+				if ($row =~ /^SHA256 \((.+?)\) = ([0-9a-f]+)/) {
+					$retval .= "$2  $1\n";
+				}
+			}
+			return $retval;
+		}
 	} else {
 		logprint(0,"Empty isolist $url\n");
 		return 0;

--- a/frontend/isoredirect.py
+++ b/frontend/isoredirect.py
@@ -27,8 +27,8 @@ except:
   # this is only a "nice to have" list
   pass
 
-@route('/<branch:re:(centos|altarch)>/<release:re:[6789](\.[0-9.]+)?>/isos/<arch:re:(x86_64|aarch64|armhfp|i386|power9|ppc64(le)?)/?><filename:re:[-A-Za-z0-9._]*>')
-def home(branch, release, arch, filename):
+@route('/<branch:re:(centos|altarch)>/<release:re:[6789](\.[0-9.]+)?>/<filetype:re:(isos|images)>/<arch:re:(x86_64|aarch64|armhfp|i386|power9|ppc64(le)?)/?><filename:re:[-A-Za-z0-9._]*>')
+def home(branch, release, filetype, arch, filename):
   ip=request.remote_route[-1]
   cc=request.query.cc
   debug=request.query.debug
@@ -58,9 +58,9 @@ def home(branch, release, arch, filename):
 
   # make sure the request is valid by checking if there is a fallback file (there should always be one)
   if len(filename) > 0:
-    mirrorlist_fallback = 'ipv4/%s/%s/isos/%s/%s.fallback' % (branch, release, arch, filename)
+    mirrorlist_fallback = 'ipv4/%s/%s/%s/%s/%s.fallback' % (branch, release, filetype, arch, filename)
   else:
-    mirrorlist_fallback = 'ipv4/%s/%s/isos/%s/iso.fallback' % (branch, release, arch)
+    mirrorlist_fallback = 'ipv4/%s/%s/%s/%s/iso.fallback' % (branch, release, filetype, arch)
 
   if not os.path.isfile('views/%s' % (mirrorlist_fallback)):
     response.status=404
@@ -109,9 +109,9 @@ Packaged copies of various torrent clients for CentOS can be found in the reposi
     c = countrylist[i]
 
     if len(filename) > 0:
-      mirrorlist_file = 'ipv4/%s/%s/isos/%s/%s.%s' % (branch, release, arch, filename, c)
+      mirrorlist_file = 'ipv4/%s/%s/%s/%s/%s.%s' % (branch, release, filetype, arch, filename, c)
     else:
-      mirrorlist_file = 'ipv4/%s/%s/isos/%s/iso.%s' % (branch, release, arch, c)
+      mirrorlist_file = 'ipv4/%s/%s/%s/%s/iso.%s' % (branch, release, filetype, arch, c)
 
     try:
       if os.path.isfile('views/%s' % (mirrorlist_file)):


### PR DESCRIPTION
- Uses CHECKSUM instead of sha256sum.txt
- disk images can now reside in either "isos" or "images"