### PR TITLE
Replace 'packer' with 'go-http-client' in cli_user_agents

### DIFF
--- a/frontend/isoredirect.py
+++ b/frontend/isoredirect.py
@@ -10,7 +10,7 @@ import time
 geodb = geoip2.database.Reader('/usr/share/GeoIP/GeoLite2-City.mmdb')
 
 # list of cli tools for which we'll just directly redirect instead of giving a list
-cli_user_agents= [ 'curl', 'wget', 'packer', 'ansible-httpget' ]
+cli_user_agents= [ 'curl', 'wget', 'go-http-client', 'ansible-httpget' ]
 
 # Json file holding the nearby countries list, generated from geo_cc.pm with convert_ccgroups_to_json.pl
 with open('ccgroups.json') as ccgroupjson:


### PR DESCRIPTION
This resolves [bco#17199](https://bugs.centos.org/view.php?id=17199). In [bco#16816](https://bugs.centos.org/view.php?id=16816) I wrongly requested `packer` to be added to the list of HTTP User Agents with Fast Redirect. Instead `go-http-client` UA is need for Packer.