### PR TITLE
Support Python requests as CLI user agent

### DIFF
--- a/frontend/isoredirect.py
+++ b/frontend/isoredirect.py
@@ -10,7 +10,7 @@ import time
 geodb = geoip2.database.Reader('/usr/share/GeoIP/GeoLite2-City.mmdb')
 
 # list of cli tools for which we'll just directly redirect instead of giving a list
-cli_user_agents= [ 'curl', 'wget', 'aria2', 'node-fetch', 'go-http-client', 'ansible-httpget' ]
+cli_user_agents= [ 'curl', 'wget', 'aria2', 'node-fetch', 'go-http-client', 'ansible-httpget', 'python-requests' ]
 
 # Json file holding the nearby countries list, generated from geo_cc.pm with convert_ccgroups_to_json.pl
 with open('ccgroups.json') as ccgroupjson:


### PR DESCRIPTION
This allows to fetch content using the Python requests library without explicitly setting an user agent.

Signed-off-by: Pino Toscano <ptoscano@redhat.com>